### PR TITLE
Update sxd crate and fix version conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ readme = "README.md"
 default = []
 
 [dependencies]
-sxd-document = "0.2"
+sxd-document = "0.3"
 sxd-xpath = "0.4"
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -119,7 +119,7 @@ impl<'d> Reader<'d> {
     pub fn from_str(xml: &str, context: Option<&'d Context<'d>>) -> Result<Self, Error> {
         // TODO: Display all.
         let package = sxd_parse(xml)
-            .map_err(|e| Error::internal(format!("{}", e.1[0]), ErrorKind::ParseXml))?;
+            .map_err(|e| Error::internal(format!("{}", e), ErrorKind::ParseXml))?;
 
         let context_refable = match context {
             Some(c) => Refable::Borrowed(c),


### PR DESCRIPTION
I discovered some build errors recently triggered by your crate:
```
$ cargo build
    Updating crates.io index
   Compiling typed-arena v1.4.1
   Compiling peresil v0.3.0
   Compiling quick-error v1.2.2
   Compiling sxd-document v0.3.0
   Compiling sxd-document v0.2.6
   Compiling sxd-xpath v0.4.2
   Compiling xpath_reader v0.5.0 (/home/christoph/workspace/rust/xpath_reader)
error[E0308]: mismatched types
   --> src/reader.rs:203:40
    |
203 |                 nodeset.add(Node::Root(root));
    |                                        ^^^^ expected struct `sxd_document::dom::Root`, found a different struct `sxd_document::dom::Root`
    |
    = note: expected type `sxd_document::dom::Root<'_>` (struct `sxd_document::dom::Root`)
               found type `sxd_document::dom::Root<'_>` (struct `sxd_document::dom::Root`)
note: Perhaps two different versions of crate `sxd_document` are being used?
   --> src/reader.rs:203:40
    |
203 |                 nodeset.add(Node::Root(root));
    |                                        ^^^^

error[E0277]: the trait bound `sxd_xpath::nodeset::Node<'_>: std::convert::From<sxd_document::dom::Root<'_>>` is not satisfied
   --> src/reader.rs:215:84
    |
215 |             Anchor::Root(ref package) => Some(package.as_document().root().clone().into()),
    |                                                                                    ^^^^ the trait `std::convert::From<sxd_document::dom::Root<'_>>` is not implemented for `sxd_xpath::nodeset::Node<'_>`
    |
    = help: the following implementations were found:
              <sxd_xpath::nodeset::Node<'d> as std::convert::From<sxd_document::dom::Comment<'d>>>
              <sxd_xpath::nodeset::Node<'d> as std::convert::From<sxd_document::dom::Element<'d>>>
              <sxd_xpath::nodeset::Node<'d> as std::convert::From<sxd_document::dom::Root<'d>>>
              <sxd_xpath::nodeset::Node<'d> as std::convert::From<sxd_document::dom::Text<'d>>>
            and 2 others
    = note: required because of the requirements on the impl of `std::convert::Into<sxd_xpath::nodeset::Node<'_>>` for `sxd_document::dom::Root<'_>`

error: aborting due to 2 previous errors

Some errors occurred: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: Could not compile `xpath_reader`.

To learn more, run the command again with --verbose.
```

Those errors are a bit confusing, as they complain about finding a wrong struct while expecting the same one, but it turned out that two versions of sxd-document are compiled and linked.